### PR TITLE
The random article feature must not display titles with a namespace!=A

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1225,11 +1225,18 @@ define(['jquery', 'abstractBackend', 'util', 'uiUtil', 'cookies','geometry','osa
                 alert("Error finding random article.");
             }
             else {
-                $("#articleName").html(title.name());
-                pushBrowserHistoryState(title.name());
-                $("#readingArticle").show();
-                $('#articleContent').contents().find('body').html("");
-                readArticle(title);
+                if (title.namespace === 'A') {
+                    $("#articleName").html(title.name());
+                    pushBrowserHistoryState(title.name());
+                    $("#readingArticle").show();
+                    $('#articleContent').contents().find('body').html("");
+                    readArticle(title);
+                }
+                else {
+                    // If the random title search did not end up on an article,
+                    // we try again, until we find one
+                    goToRandomArticle();
+                }
             }
         });
     }


### PR DESCRIPTION
When randomly selecting a title, we could end up on a content with any namespace
For example images, javascript, CSS etc.
Now, if this happens, we randomly select another title, until we find a content
with namespace 'A' (i.e an article).

Fixes #141 