### PR TITLE
Fix in the redirection algorithm, that was leading to the wrong article.

### DIFF
--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -194,7 +194,7 @@ define(['zimfile', 'zimDirEntry', 'util', 'utf8'],
      */
     ZIMArchive.prototype.resolveRedirect = function(title, callback) {
         var that = this;
-        this._file.dirEntryByTitleIndex(title.redirectTarget).then(function(dirEntry) {
+        this._file.dirEntryByUrlIndex(title.redirectTarget).then(function(dirEntry) {
             return that._dirEntryToTitleObject(dirEntry);
         }).then(callback);
     };


### PR DESCRIPTION
The redirection algorithm was considering the redirectTarget as a TitleIndex
instead of a UrlIndex.
That was sometimes causing some infinite loops, and often opened the wrong
article when clicking on a link.

Fixes #106
Fixes #133