### PR TITLE
Make Travis package/deploy only on cron, and change Firefox id.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ deploy:
     provider: script
     script: "./scripts/setup_travis_env.sh && DISPLAY=:99.0 ./scripts/create_all_packages.sh $TRAVIS_TAG"
     on:
-        branch: master
+        condition: ( "$TRAVIS_EVENT_TYPE" = "cron" )

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Kiwix",
-    "version": "2.0-beta",
+    "version": "2.0-WIP",
 
     "description": "Kiwix : offline wikipedia reader",
     
@@ -29,7 +29,7 @@
     
     "applications": {
         "gecko": {
-            "id": "kiwix@kiwix.org"
+            "id": "kiwix-html5-unlisted@kiwix.org"
         }
     },
 

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -1,5 +1,5 @@
 {
-  "version": "2.0-beta",
+  "version": "2.0-WIP",
   "name": "Kiwix",
   "description": "Offline Wikipedia Viewer, and more",
   "launch_path": "/www/index.html",

--- a/scripts/create_all_packages.sh
+++ b/scripts/create_all_packages.sh
@@ -12,8 +12,8 @@ if [ -r "$BASEDIR/scripts/set_secret_environment_variables.sh" ]; then
 fi
 
 # Use the first argument as a version number, else use the Travis tag, else use the commit id
-VERSION_TO_REPLACE="2\.0-beta"
-VERSION_PREFIX="2.0.0"
+VERSION_TO_REPLACE="2\.0-WIP"
+VERSION_PREFIX="2.0"
 if [ ! "$1zz" == "zz" ]; then
     VERSION=$1
     echo "Packaging version $VERSION because it has been passed as an argument"

--- a/scripts/package_listed_firefox_extension.sh
+++ b/scripts/package_listed_firefox_extension.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# This script must be run manually on each release, with the version as first parameter
+# It must be run after the create_all_packages.sh, so that the tmp directory has been populated
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
+echo "BASEDIR is $BASEDIR"
+cd $BASEDIR
+VERSION=$1
+
+echo "Replacing the Firefox 'unlisted' extension id by the 'listed' one to be accepted by Mozilla"
+sed -i -e "s/kiwix-html5-unlisted@kiwix.org/kiwix-html5-listed@kiwix.org/" tmp/manifest.json
+
+cd tmp
+echo "Packaging unsigned 'listed' Firefox extension, version $VERSION"
+zip -r ../build/kiwix-firefox-unsigned-listed-extension-$VERSION.xpi www webextension manifest.json LICENSE-GPLv3.txt service-worker.js README.md
+cd ..
+
+CURRENT_DATE=$(date +'%Y-%m-%d')
+# Upload the files on download.kiwix.org
+echo "Uploading the file on http://download.kiwix.org/nightly/$CURRENT_DATE/"
+scp -r -p -i scripts/travisci_builder_id_key build/* nightlybot@download.kiwix.org:/var/www/download.kiwix.org/nightly/$CURRENT_DATE

--- a/www/index.html
+++ b/www/index.html
@@ -51,7 +51,7 @@
                       <span class="icon-bar"></span>
                       <span class="icon-bar"></span>
                     </button>
-                    <a class="navbar-brand">Kiwix 2.0-beta</a>
+                    <a class="navbar-brand">Kiwix 2.0-WIP</a>
                   </div>
 
                   <!-- Collect the nav links, forms, and other content for toggling -->


### PR DESCRIPTION
The firefox extension id is kiwix-html5-unlisted by default.
The new package_listed_firefox_extension.sh allows to change this id
and upload a package ready to be submitted to Mozilla.

Fixes #213