### PR TITLE
Change case of wikipedia and wikimedia words in UI and README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 kiwix-html5
 ==============
 
-Kiwix is an offline wikipedia viewer. See the official site: http://www.kiwix.org/
+Kiwix is an offline Wikipedia viewer. See the official site: http://www.kiwix.org/
 
 This is a browser extension developed in HTML5/Javascript.
 
 You can search among the article titles, and read any of them without any Internet access.
-All the content of wikipedia is inside your device (including the images).
-It might also works with other content in the OpenZIM format: http://www.openzim.org/wiki/OpenZIM , but has been only tested on the wikipedia ones.
+All the content of Wikipedia is inside your device (including the images).
+It might also works with other content in the OpenZIM format: http://www.openzim.org/wiki/OpenZIM , but has been only tested on the Wikipedia ones.
 
 If your Internet access is expensive/rare/slow/unreliable/watched/censored, you still can browse this amazing amount of knowledge and culture.
 
@@ -16,7 +16,7 @@ You have to download them separately, store them in your filesystem, and manuall
 It is unfortunately not technically possible to "remember" the selected ZIM file and open it automatically (the browsers refuse that for security reasons).
 
 Technically, after reading an article from a ZIM file, there is a need to "inject" the dependencies (images, css etc). For compatibility reasons, there are several ways to do it :
-- the "jQuery" mode parses the DOM to find the HTML tags of these dependencies, and modifies them to put the Base64 content in it. It is compatible with any browser, but is slow and can use a lot of memory. It works well on wikimedia content, but can miss some dependencies on some contents
+- the "jQuery" mode parses the DOM to find the HTML tags of these dependencies, and modifies them to put the Base64 content in it. It is compatible with any browser, but is slow and can use a lot of memory. It works well on Wikimedia content, but can miss some dependencies on some contents
 - the "ServiceWorker" mode uses a Service Worker to catch any HTTP request the page would send, and reply with content read from the ZIM file. It is a generic and much cleaner way than jQuery mode, but it does not work on all browsers. And ServiceWorkers are disabled by Mozilla in Firefox extensions
 - maybe a "webRequest" mode will appear, which would use the webRequest API inside the Firefox extension (when the necessary APIs will be implemented by Mozilla)
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "name": "Kiwix",
     "version": "2.0-WIP",
 
-    "description": "Kiwix : offline wikipedia reader",
+    "description": "Kiwix : offline Wikipedia reader",
     
     "icons": {
         "16": "www/img/icons/kiwix-16.png",

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -20,7 +20,7 @@
   "default_locale": "en",
   "permissions": {
     "device-storage:sdcard": {
-      "description": "Required to read wikipedia archives",
+      "description": "Required to read Wikipedia archives",
       "access": "readonly"
     },
     "geolocation": {

--- a/www/index.html
+++ b/www/index.html
@@ -4,10 +4,10 @@
         <meta charset="utf-8">
 
         <title>Kiwix</title>
-        <meta name="description" content="Offline wikipedia reader">
+        <meta name="description" content="Offline Wikipedia reader">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <!--
-        Kiwix (offline wikipedia reader) - HTML5/Javascript version
+        Kiwix (offline Wikipedia reader) - HTML5/Javascript version
         Home page : http://www.kiwix.org
 
         Main authors of this application :
@@ -106,7 +106,7 @@
                     <h3>Usage</h3>
                     <h4>Step 1 : download some content</h4>
                     from <a href="http://download.kiwix.org/zim" target="_blank">http://download.kiwix.org/zim/</a>, with a regular computer.
-                    <strong>Currently only wikimedia contents (ZIM files in wiki* subdirectories, for instance <a href="http://download.kiwix.org/zim/wikipedia/" target="_blank">http://download.kiwix.org/zim/wikipedia/</a>) have been tested</strong>.
+                    <strong>Currently only Wikimedia contents (ZIM files in wiki* subdirectories, for instance <a href="http://download.kiwix.org/zim/wikipedia/" target="_blank">http://download.kiwix.org/zim/wikipedia/</a>) have been tested</strong>.
                     There are known bugs when reading other contents; and audio/video/dynamic contents are not supported for now.
                     <br />For a quick test, you can start with the <a href="http://download.kiwix.org/zim/wikipedia/wikipedia_en_ray_charles_2015-06.zim" target="_blank">"Ray Charles" ZIM file</a> : it contains some wikipedia articles about Ray Charles.
                     <br />After that, you can download materials in your language. Check the size before you download files as many of the files are large (several Gigabytes).
@@ -115,7 +115,7 @@
                     <h4>Step 2 : copy the content onto your device</h4>
                     If you have enough space, you can put several archives.
                     <h4>Step 3 : open the extension, go to the "Configure" menu and select your ZIM file</h4>
-                    <h4>Step 4 : enjoy wikipedia offline!</h4>
+                    <h4>Step 4 : enjoy Wikipedia offline!</h4>
                     <h3>Privacy policy</h3>
                     <h4>Short answer :</h4>
                     This application works offline. We do not collect any of your personal data and don't even know what you are doing with this application.
@@ -194,7 +194,7 @@
                     <div id="openLocalFiles" style="display: none;">
                         Please select the .zim file (or all the .zimaa, .zimab etc in case of a split ZIM file)<br />
                         <input type="file" id="archiveFiles" multiple class="btn" accept=".zim,.dat,.idx,.txt,.zimaa,.zimab,.zimac,.zimad,.zimae,.zimaf,.zimag,.zimah,.zimai,.zimaj,.zimak,.zimal,.zimam,.ziman,.zimao,.zimap,.zimaq,.zimar,.zimas,.zimat,.zimau,.zimav,.zimaw,.zimax,.zimay,.zimaz" /><br />
-                        <strong>Only wikimedia contents (wiki*.zim* files) have been tested</strong> for now. There are known bugs on other contents, and audio/video/dynamic contents are not supported for now.<br />
+                        <strong>Only Wikimedia contents (wiki*.zim* files) have been tested</strong> for now. There are known bugs on other contents, and audio/video/dynamic contents are not supported for now.<br />
                     </div>
                     <div id="scanningForArchives" style="display: none;">
                         <br /> Scanning for archives... Please wait <img src="img/spinner.gif" alt="Please wait..." />

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -496,7 +496,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             $("#btnAbout").click();
             var isAndroid = (navigator.userAgent.indexOf("Android") !== -1);
             if (isAndroid) {
-                alert("You seem to be using an Android device. Be aware that there is a bug on Firefox, that prevents finding wikipedia archives in a SD-card (at least on some devices. See about section). Please put the archive in the internal storage if the application can't find it.");
+                alert("You seem to be using an Android device. Be aware that there is a bug on Firefox, that prevents finding Wikipedia archives in a SD-card (at least on some devices. See about section). Please put the archive in the internal storage if the application can't find it.");
             }
         }
     }
@@ -820,7 +820,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                         || util.endsWith(lowerCaseUrl, ".svg")
                         || util.endsWith(lowerCaseUrl, ".jpg")
                         || util.endsWith(lowerCaseUrl, ".jpeg"))) {
-                    // It's a link to a file of wikipedia : change the URL to the online version and open in a new tab
+                    // It's a link to a file of Wikipedia : change the URL to the online version and open in a new tab
                     var onlineWikipediaUrl = url.replace(regexpImageLink, "https://" + selectedArchive._language + ".wikipedia.org/wiki/File:$1");
                     $(this).attr("href", onlineWikipediaUrl);
                     $(this).attr("target", "_blank");


### PR DESCRIPTION
There must be an uppercase as the first letter.
Fixes #225