### PR TITLE
Fixes #177 History Navigation

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -251,7 +251,7 @@ define(['jquery', 'zimArchive', 'zimDirEntry', 'util', 'utf8'],
             localZimArchive.getTitleByName("I/m/RayCharles_AManAndHisSoul.jpg").then(function(title) {
                 assert.ok(title !== null, "Title found");
                 if (title !== null) {
-                    assert.equal(title.url, "I/m/RayCharles_AManAndHisSoul.jpg", "URL is correct.");
+                    assert.equal(title.namespace +"/"+ title.url, "I/m/RayCharles_AManAndHisSoul.jpg", "URL is correct.");
                     localZimArchive.readBinaryFile(title, function(title, data) {
                         assert.equal(data.length, 4951, "Data length is correct.");
                         var beginning = new Uint8Array([255, 216, 255, 224, 0, 16, 74, 70,
@@ -271,7 +271,7 @@ define(['jquery', 'zimArchive', 'zimDirEntry', 'util', 'utf8'],
             localZimArchive.getTitleByName("-/s/style.css").then(function(title) {
                 assert.ok(title !== null, "Title found");
                 if (title !== null) {
-                    assert.equal(title.url, "-/s/style.css", "URL is correct.");
+                    assert.equal(title.namespace +"/"+ title.url, "-/s/style.css", "URL is correct.");
                     localZimArchive.readBinaryFile(title, function(title, data) {
                         assert.equal(data.length, 104495, "Data length is correct.");
                         data = utf8.parse(data);
@@ -290,7 +290,7 @@ define(['jquery', 'zimArchive', 'zimDirEntry', 'util', 'utf8'],
             localZimArchive.getTitleByName("-/j/local.js").then(function(title) {
                 assert.ok(title !== null, "Title found");
                 if (title !== null) {
-                    assert.equal(title.url, "-/j/local.js", "URL is correct.");
+                    assert.equal(title.namespace +"/"+ title.url, "-/j/local.js", "URL is correct.");
                     localZimArchive.readBinaryFile(title, function(title, data) {
                         assert.equal(data.length, 41, "Data length is correct.");
                         data = utf8.parse(data);
@@ -310,7 +310,7 @@ define(['jquery', 'zimArchive', 'zimDirEntry', 'util', 'utf8'],
             localZimArchive.getTitleByName("A/Ray_Charles.html").then(function(title) {
                 assert.ok(title !== null, "Title found");
                 if (title !== null) {
-                    assert.equal(title.url, "A/Ray_Charles.html", "URL is correct.");
+                    assert.equal(title.namespace +"/"+ title.url, "A/Ray_Charles.html", "URL is correct.");
                     localZimArchive.readArticle(title, function(titleName, data) {
                         assert.equal(titleName, "Ray Charles", "Title is correct.");
                         assert.equal(data.length, 157186, "Data length is correct.");

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -680,7 +680,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
         $("#prefix").val("");
         findTitleFromTitleIdAndLaunchArticleRead(titleId);
         var title = selectedArchive.parseTitleId(titleId);
-        pushBrowserHistoryState(title.name());
+        pushBrowserHistoryState(title.url);
         return false;
     }
     
@@ -838,9 +838,9 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
                         url = url.substring(1);
                     }
                     $(this).on('click', function(e) {
-                        var titleName = decodeURIComponent(url);
-                        pushBrowserHistoryState(titleName);
-                        goToArticle(titleName);
+                        var decodedURL = decodeURIComponent(url);
+                        pushBrowserHistoryState(decodedURL);
+                        goToArticle(decodedURL);
                         return false;
                     });
                 }
@@ -985,7 +985,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             else {
                 if (title.namespace === 'A') {
                     $("#articleName").html(title.name());
-                    pushBrowserHistoryState(title.name());
+                    pushBrowserHistoryState(title.url);
                     $("#readingArticle").show();
                     $('#articleContent').contents().find('body').html("");
                     readArticle(title);
@@ -1007,7 +1007,7 @@ define(['jquery', 'zimArchiveLoader', 'util', 'uiUtil', 'cookies','abstractFiles
             else {
                 if (title.namespace === 'A') {
                     $("#articleName").html(title.name());
-                    pushBrowserHistoryState(title.name());
+                    pushBrowserHistoryState(title.url);
                     $("#readingArticle").show();
                     $('#articleContent').contents().find('body').html("");
                     readArticle(title);

--- a/www/js/lib/zimDirEntry.js
+++ b/www/js/lib/zimDirEntry.js
@@ -54,7 +54,7 @@ define([], function() {
         this.redirectTarget = dirEntryData.redirectTarget;
         this.cluster = dirEntryData.cluster;
         this.blob = dirEntryData.blob;
-        this.url = dirEntryData.namespace + '/' + dirEntryData.url;
+        this.url = dirEntryData.url;
         this.title = dirEntryData.title;
     };
 


### PR DESCRIPTION
"article URL" should have been used instead of "article Title" when saving browser history state. But when these terms are being read from the DirEntry "article Namespace" is being prepended to url and stored as url. The fix is to stop doing this prepending. That keeps it consistent to the reader when "DirEntry.url" is reqd and when "DirEntry.namespace + '/' + DirEntry.url" is required. Further details [here](https://github.com/kiwix/kiwix-html5/issues/177#issuecomment-296538463)

Changes:
www/js/zimDirEntry.js
url should not hold namespace + url

www/js/app.js
In gotoRandom, handleTitleClick, gotoMainArticle
now passes title.url instead of title.name() to pushBrowserHistoryState

www/js/app.js, tests/tests.js
Replaced occurances of title.url with title.namespace + title.url